### PR TITLE
Waffle logger hotfix

### DIFF
--- a/waffle_utils/__init__.py
+++ b/waffle_utils/__init__.py
@@ -1,6 +1,1 @@
 __version__ = "0.2.0"
-
-
-from waffle_utils.log import initialize_logger
-
-initialize_logger()

--- a/waffle_utils/log/template.py
+++ b/waffle_utils/log/template.py
@@ -13,7 +13,7 @@ DEFAULT_ROOT_LEVEL = logging.WARNING
 DEFAULT_CONSOLE_LEVEL = logging.INFO
 DEFAULT_FILE_LEVEL = logging.DEBUG
 
-DEFAULT_TIMED_ROATETING_WHEN = "H"
+DEFAULT_TIMED_ROATETING_WHEN = "D"
 DEFAULT_TIMED_ROATETING_INTERVAL = 1
 DEFAULT_ENCODING = "utf8"
 
@@ -23,7 +23,7 @@ class LogLevel:
 
 
 def initialize_logger(
-    file_path: Union[str, Path] = "logs/waffle.log",
+    file_path: Union[str, Path],
     console_level: LogLevel = DEFAULT_CONSOLE_LEVEL,
     file_level: LogLevel = DEFAULT_FILE_LEVEL,
     root_level: LogLevel = DEFAULT_ROOT_LEVEL,

--- a/waffle_utils/run.py
+++ b/waffle_utils/run.py
@@ -1,14 +1,12 @@
 import logging
 
 import typer
-from rich import print
 
 from waffle_utils.dataset import Dataset
 from waffle_utils.dataset.format import Format
 from waffle_utils.file.io import unzip
 from waffle_utils.file.network import get_file_from_url
 from waffle_utils.image import DEFAULT_IMAGE_EXTENSION, SUPPORTED_IMAGE_EXTENSION
-from waffle_utils.log import logging
 from waffle_utils.video import SUPPORTED_VIDEO_EXTENSION
 from waffle_utils.video.tools import DEFAULT_FRAME_RATE, create_video, extract_frames
 


### PR DESCRIPTION
closes #44 
- default `initialize_logger` call generates logs/waffle.log file.
- This was an unexpected feature.
- => Call `initialize_logger` once directly in your project.