### PR TITLE
Add `StrEnum`, `BaseHook`, `BaseCallback`

### DIFF
--- a/tests/enum/test_enum.py
+++ b/tests/enum/test_enum.py
@@ -1,0 +1,89 @@
+# Copyright The PyTorch Lightning team.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+from enum import Enum
+
+from waffle_utils.enum import StrEnum
+
+
+def test_consistency():
+    class MyEnum(StrEnum):
+        FOO = "FOO"
+        BAR = "BAR"
+        BAZ = "BAZ"
+        NUM = "32"
+
+    # normal equality, case invariant
+    assert MyEnum.FOO == "FOO"
+    assert MyEnum.FOO == "foo"
+
+    # int support
+    assert MyEnum.NUM == 32
+    assert MyEnum.NUM in (32, "32")
+
+    # key-based
+    assert MyEnum.from_str("num") == MyEnum.NUM
+
+    # collections
+    assert MyEnum.BAZ not in ("FOO", "BAR")
+    assert MyEnum.BAZ in ("FOO", "BAZ")
+    assert MyEnum.BAZ in ("baz", "FOO")
+    assert MyEnum.BAZ not in {"BAR", "FOO"}
+    # hash cannot be case invariant
+    assert MyEnum.BAZ not in {"BAZ", "FOO"}
+    assert MyEnum.BAZ in {"baz", "FOO"}
+
+
+def test_comparison_with_other_enum():
+    class MyEnum(StrEnum):
+        FOO = "FOO"
+
+    class OtherEnum(Enum):
+        FOO = 123
+
+    assert not MyEnum.FOO.__eq__(OtherEnum.FOO)
+
+
+def test_create_from_string():
+    class MyEnum(StrEnum):
+        t1 = "T/1"
+        T2 = "t:2"
+
+    assert MyEnum.from_str("T1", source="key")
+    assert MyEnum.try_from_str("T1", source="value") is None
+    assert MyEnum.from_str("T1", source="any")
+
+    assert MyEnum.try_from_str("T:2", source="key") is None
+    assert MyEnum.from_str("T:2", source="value")
+    assert MyEnum.from_str("T:2", source="any")
+
+
+# additional custom test code
+def test_iter():
+    class MyEnum(StrEnum):
+        FOO = "FOO"
+        BAR = "BAR"
+        BAZ = "BAZ"
+        NUM = "32"
+
+    assert list(MyEnum) == [MyEnum.FOO, MyEnum.BAR, MyEnum.BAZ, MyEnum.NUM]
+
+    members = []
+    for member in MyEnum:
+        members.append(member)
+    assert members == [MyEnum.FOO, MyEnum.BAR, MyEnum.BAZ, MyEnum.NUM]
+
+    assert MyEnum.FOO in MyEnum
+
+    assert MyEnum.FOO in {
+        MyEnum.FOO: "something",
+    }
+
+
+def test_str_util():
+    class MyEnum(StrEnum):
+        FOO = "FOO"
+
+    assert MyEnum.FOO.lower() == "foo"
+    assert MyEnum.FOO.upper() == "FOO"

--- a/tests/hook/test_hook.py
+++ b/tests/hook/test_hook.py
@@ -1,0 +1,83 @@
+import pytest
+
+from waffle_utils.callback import BaseCallback
+from waffle_utils.hook import BaseHook
+
+
+def test_run_hook():
+    data = {}
+
+    class Foo(BaseHook):
+        pass
+
+    class CustomCallback1(BaseCallback):
+        def on_event_1(self, *args, **kwargs):
+            data["event_1"] = True
+
+    class CustomCallback2(BaseCallback):
+        def on_event_2(self, *args, **kwargs):
+            data["event_2"] = True
+
+    #
+    data.clear()
+    foo = Foo(callbacks=[CustomCallback1()])
+    foo.run_hook("on_event_1")
+    assert "event_1" in data
+
+    foo.run_hook("on_event_2")
+    assert "event_2" not in data
+
+    #
+    data.clear()
+    foo = Foo(callbacks=[CustomCallback1(), CustomCallback2()])
+    foo.run_hook("on_event_1")
+    assert "event_1" in data
+
+    foo.run_hook("on_event_2")
+    assert "event_2" in data
+
+    #
+    data.clear()
+    foo = Foo(callbacks=[CustomCallback1()])
+    foo.run_hook("on_event_1")
+    assert "event_1" in data
+
+    foo.run_hook("on_event_2")
+    assert "event_2" not in data
+
+    foo.register_callback(CustomCallback2())
+    foo.run_hook("on_event_2")
+    assert "event_2" in data
+
+    data.clear()
+    foo.unregister_callback(1)
+    foo.run_hook("on_event_2")
+    assert "event_2" not in data
+
+
+def test_callback():
+    class CustomCallback(BaseCallback):
+        pass
+
+    callback1 = CustomCallback()
+    callback2 = CustomCallback()
+
+    assert callback1 == callback2
+
+    with pytest.raises(ValueError):
+        BaseHook(callbacks=[callback1, callback1])
+
+    class CustomCallback(BaseCallback):
+        def __init__(self, name):
+            self.name = name
+
+        @property
+        def state_key(self):
+            return self.name
+
+    callback1 = CustomCallback("callback1")
+    callback2 = CustomCallback("callback2")
+
+    assert callback1 != callback2
+
+    BaseHook(callbacks=[callback1, callback2])

--- a/waffle_utils/callback/__init__.py
+++ b/waffle_utils/callback/__init__.py
@@ -1,0 +1,5 @@
+from .callback import BaseCallback
+
+__all__ = [
+    "BaseCallback",
+]

--- a/waffle_utils/callback/callback.py
+++ b/waffle_utils/callback/callback.py
@@ -1,0 +1,17 @@
+class BaseCallback:
+    def __init__(self) -> None:
+        pass
+
+    @property
+    def state_key(self) -> str:
+        """Return the state key.
+
+        Can be overwritten by subclasses.
+        """
+        return self.__class__.__qualname__
+
+    def __eq__(self, other: object) -> bool:
+        """Compare two instances."""
+        if issubclass(other.__class__, BaseCallback):
+            return self.state_key == other.state_key
+        return False

--- a/waffle_utils/enum/__init__.py
+++ b/waffle_utils/enum/__init__.py
@@ -1,0 +1,3 @@
+from .enum import StrEnum
+
+__all__ = ["StrEnum"]

--- a/waffle_utils/enum/enum.py
+++ b/waffle_utils/enum/enum.py
@@ -1,0 +1,99 @@
+# Copyright The PyTorch Lightning team.
+# Licensed under the Apache License, Version 2.0 (the "License");
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+import warnings
+from enum import Enum
+from typing import List, Optional
+
+from typing_extensions import Literal
+
+
+class StrEnum(str, Enum):
+    """Type of any enumerator with allowed comparison to string invariant to cases.
+
+    >>> class MySE(StrEnum):
+    ...     t1 = "T-1"
+    ...     t2 = "T-2"
+    >>> MySE("T-1") == MySE.t1
+    True
+    >>> MySE.from_str("t-2", source="value") == MySE.t2
+    True
+    >>> MySE.from_str("t-2", source="value")
+    <MySE.t2: 'T-2'>
+    >>> MySE.from_str("t-3", source="any")
+    Traceback (most recent call last):
+      ...
+    ValueError: Invalid match: expected one of ['t1', 't2', 'T-1', 'T-2'], but got t-3.
+
+    """
+
+    @classmethod
+    def from_str(
+        cls, value: str, source: Literal["key", "value", "any"] = "key"
+    ) -> "StrEnum":
+        """Create ``StrEnum`` from a string matching the key or value.
+
+        Args:
+            value: matching string
+            source: compare with:
+
+                - ``"key"``: validates only from the enum keys, typical alphanumeric with "_"
+                - ``"value"``: validates only from the values, could be any string
+                - ``"any"``: validates with any key or value, but key has priority
+
+        Raises:
+            ValueError:
+                if requested string does not match any option based on selected source.
+
+        """
+        if source in ("key", "any"):
+            for enum_key in cls.__members__:
+                if enum_key.lower() == value.lower():
+                    return cls[enum_key]
+        if source in ("value", "any"):
+            for enum_key, enum_val in cls.__members__.items():
+                if enum_val == value:
+                    return cls[enum_key]
+        raise ValueError(
+            f"Invalid match: expected one of {cls._allowed_matches(source)}, but got {value}."
+        )
+
+    @classmethod
+    def try_from_str(
+        cls, value: str, source: Literal["key", "value", "any"] = "key"
+    ) -> Optional["StrEnum"]:
+        """Try to create emun and if it does not match any, return `None`."""
+        try:
+            return cls.from_str(value, source)
+        except ValueError:
+            warnings.warn(  # noqa: B028
+                UserWarning(
+                    f"Invalid string: expected one of {cls._allowed_matches(source)}, but got {value}."
+                )
+            )
+        return None
+
+    @classmethod
+    def _allowed_matches(cls, source: str) -> List[str]:
+        keys, vals = [], []
+        for enum_key, enum_val in cls.__members__.items():
+            keys.append(enum_key)
+            vals.append(enum_val.value)
+        if source == "key":
+            return keys
+        if source == "value":
+            return vals
+        return keys + vals
+
+    def __eq__(self, other: object) -> bool:
+        """Compare two instances."""
+        if isinstance(other, Enum):
+            other = other.value
+        return self.value.lower() == str(other).lower()
+
+    def __hash__(self) -> int:
+        """Return unique hash."""
+        # re-enable hashtable, so it can be used as a dict key or in a set
+        # example: set(LightningEnum)
+        return hash(self.value.lower())

--- a/waffle_utils/enum/enum.py
+++ b/waffle_utils/enum/enum.py
@@ -4,9 +4,7 @@
 #
 import warnings
 from enum import Enum
-from typing import List, Optional
-
-from typing_extensions import Literal
+from typing import List, Literal, Optional
 
 
 class StrEnum(str, Enum):

--- a/waffle_utils/hook/__init__.py
+++ b/waffle_utils/hook/__init__.py
@@ -1,0 +1,5 @@
+from .hook import BaseHook
+
+__all__ = [
+    "BaseHook",
+]

--- a/waffle_utils/hook/hook.py
+++ b/waffle_utils/hook/hook.py
@@ -1,0 +1,41 @@
+from waffle_utils.callback import BaseCallback
+
+
+class BaseHook:
+    def __init__(self, callbacks: list[BaseCallback] = None):
+        self.callbacks = []
+        if callbacks is not None:
+            for callback in callbacks:
+                self.register_callback(callback)
+        self.hooks = []
+
+    @property
+    def callbacks(self):
+        return self._callbacks
+
+    @callbacks.setter
+    def callbacks(self, value):
+        self._callbacks = value
+
+    def register_callback(self, callback: BaseCallback):
+        """Register a callback."""
+        if self._check_callback_exist(callback):
+            raise ValueError("Callback already exist.")
+        self.callbacks.append(callback)
+
+    def unregister_callback(self, callback_idx: int):
+        """Unregister a callback."""
+        del self.callbacks[callback_idx]
+
+    def _check_callback_exist(self, callback: BaseCallback) -> bool:
+        for _callback in self.callbacks:
+            if _callback == callback:
+                return True
+        return False
+
+    def run_hook(self, hook_name, *args, **kwargs):
+        """Run a hook."""
+        for callback in self.callbacks:
+            fn = getattr(callback, hook_name, None)
+            if fn is not None:
+                fn(*args, **kwargs)


### PR DESCRIPTION
- add some base classes for Waffle components (or general purpose)
- this PR is based on [pytorch_lightning](https://github.com/Lightning-AI/pytorch-lightning) implementation.
- you can see the usage of these classes in `tests/enum/test_enum.py` `tests/hook/test_hook.py`.